### PR TITLE
Add constructor to initialize formatter settings

### DIFF
--- a/src/main/java/transformj/TJ_Matrix.java
+++ b/src/main/java/transformj/TJ_Matrix.java
@@ -73,6 +73,11 @@ public class TJ_Matrix implements PlugIn, ActionListener, ClipboardOwner, FocusL
 	private static int shearingAxis = 0;
 	private static int drivingAxis = 0;
 	
+	public TJ_Matrix() {
+		formatter.decs(10);
+		formatter.chop(1E-10);
+	}
+	
 	public void run(String arg) {
 		
 		if (!TJ.check()) return;


### PR DESCRIPTION
Previously, the settings were only initialized in the `run` method, leading to unexpected results (too few decimal places in saved matrix) when using TJ_Matrix() from a script.
